### PR TITLE
ELPA compatibility

### DIFF
--- a/pomodoro.el
+++ b/pomodoro.el
@@ -3,6 +3,7 @@
 
 ;; Author: Dave Kerschner <docgnome@docgno.me>
 ;; Created: Aug 25, 2010
+;; Version: 0.1
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -143,3 +144,4 @@
 (setq-default mode-line-format (cons '(pomodoro-mode-line-string pomodoro-mode-line-string) mode-line-format))
 
 (provide 'pomodoro)
+;;; pomodoro.el ends here


### PR DESCRIPTION
Hello!

ELPA (package manager of Emacs 24) requires, that every package has ";; Version:" header and ";;; <package>.el ends here" footer, otherwise it complains. I added these. Please change the version header to any you feel right.

Good day.
