### PR TITLE
Cancel timer on pomodoro-start when one is already running

### DIFF
--- a/pomodoro.el
+++ b/pomodoro.el
@@ -141,6 +141,8 @@
 			(car arg))
 		    arg
 		    pomodoro-work-time)))
+    (when pomodoro-timer
+      (cancel-timer pomodoro-timer))
     (setq pomodoro-work-time timer)
     (pomodoro-set-start-time pomodoro-work-time)
     (setq pomodoro-timer (run-with-timer 0 1 'pomodoro-tick))))


### PR DESCRIPTION
Without this patch, calling pomodoro-start multiple times turns
pomodoro-mode into sisyphus-mode as there is no way to stop the timers
started before the last one anymore. With this patch an already
running timer is stopped before starting a new one.
