### PR TITLE
Added function to add to mode line

### DIFF
--- a/pomodoro.el
+++ b/pomodoro.el
@@ -67,7 +67,7 @@
   :group 'pomodoro
   :type 'string)
 
-(defcustom pomodoro-work-start-message "Back to work slave!"
+(defcustom pomodoro-work-start-message "Back to work, slave!"
   "Message to show when a work period starts"
   :group 'pomodoro
   :type 'string)
@@ -159,7 +159,10 @@
   (interactive)
   (call-process pomodoro-sound-player nil 0 nil (expand-file-name pomodoro-break-start-sound)))
 
-(setq-default mode-line-format (cons '(pomodoro-mode-line-string pomodoro-mode-line-string) mode-line-format))
+(defun pomodoro-add-to-mode-line ()
+ (setq-default mode-line-format 
+               (cons '(pomodoro-mode-line-string pomodoro-mode-line-string) 
+	             mode-line-format)))
 
 (provide 'pomodoro)
 ;;; pomodoro.el ends here


### PR DESCRIPTION
Added a function to add pomodoro timer to the modeline to allow for more customization.  This does make the user have to do one extra thing when starting to use pomodoro, but at the same time also allows the users extra customization in that it is now possible to add the modeline-string to other places in the modeline without having trouble with the current approach.

F.ex. adding the modeline-string to the end of the modeline instead of the beginning would be difficult with the previous approach without getting two pomodoro timers. 

Also corrected a grammatical error.
