### PR TITLE
Fix compiler warnings

### DIFF
--- a/pomodoro.el
+++ b/pomodoro.el
@@ -94,9 +94,10 @@
 
 
 (defvar pomodoro-timer nil)
-(defvar pomodoros 0)
+(with-no-warnings (defvar pomodoros 0))
 (defvar pomodoro-current-cycle nil)
-(defvar pomodor-mode-line-string "")
+(defvar pomodoro-mode-line-string "")
+(defvar pomodoro-start-time)
 
 (defun pomodoro-epoch (c)
   (+ (* (car c) (expt 2 16)) (cadr c)))


### PR DESCRIPTION
This patch fixes the compiler warnings that emacs shows when byte-compiling.

```
In pomodoro-set-start-time:
pomodoro.el:118:9:Warning: assignment to free variable `pomodoro-start-time'

In pomodoro-tick:
pomodoro.el:121:18:Warning: reference to free variable `pomodoro-start-time'
pomodoro.el:142:11:Warning: assignment to free variable `pomodoro-mode-line-string'

In pomodoro-stop:
pomodoro.el:161:9:Warning: assignment to free variable `pomodoro-mode-line-string'
```
