### PR TITLE
Fix error in seconds format

### DIFF
--- a/pomodoro.el
+++ b/pomodoro.el
@@ -126,9 +126,8 @@
             (setq pomodoro-current-cycle pomodoro-work-cycle)
             (pomodoro-set-end-time pomodoro-work-time))))
     (setq pomodoro-mode-line-string
-          (format "%s%s "
-                  pomodoro-current-cycle
-                  (format-seconds ".2%m:.2%s" time)))
+          (format (concat "%s" (format-seconds "%.2m:%.2s " time))
+                  pomodoro-current-cycle))
     (force-mode-line-update)))
 
 (defun pomodoro-start (arg)


### PR DESCRIPTION
I made en an error in the format-seconds. I think I might have pressed transpose or something right before I commited. I don't really understand how that happened. Now it gives correct output and is easier to read then before.
