### PR TITLE
add autoload for pomodoro-start

### DIFF
--- a/pomodoro.el
+++ b/pomodoro.el
@@ -131,6 +131,7 @@
                   (format-seconds ".2%m:.2%s" time)))
     (force-mode-line-update)))
 
+;;;###autoload
 (defun pomodoro-start (arg)
   (interactive "P")
   (let* ((timer (or (if (listp arg)


### PR DESCRIPTION
so that when we download pomodoro through elpa the autoloads are automatically set up and we can use `(require 'pomodoro-autoloads)` instead of the usual way of `require`ing before we actually need it.
