### PR TITLE
Silence Compiler Warnings About 'cl' Functions

### DIFF
--- a/pomodoro.el
+++ b/pomodoro.el
@@ -22,6 +22,9 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'cl))
+
 (defgroup pomodoro nil
   "Timer for the Pomodoro Technique in emacs"
   :prefix "pomodoro-"


### PR DESCRIPTION
This patch makes sure that the `cl` library is loaded, silencing two compiler warnings.  Admittedly it is unlikely for those warnings to appear because many other packages already load `cl`.  But when testing pomodoro.el in isolation (e.g. from `emacs -Q`) this helps eliminate some "compiler noise."
