### PR TITLE
Drop references to slavery

### DIFF
--- a/pomodoro.el
+++ b/pomodoro.el
@@ -75,7 +75,7 @@
   :group 'pomodoro
   :type 'string)
 
-(defcustom pomodoro-work-start-message "Back to work, slave!"
+(defcustom pomodoro-work-start-message "Back to work!"
   "Message to show when a work period starts"
   :group 'pomodoro
   :type 'string)
@@ -121,7 +121,6 @@ Formatted with `format-seconds'."
 
 (defun pomodoro-set-end-time (minutes)
   "Set how long the pomodoro timer should run"
-  ;; no slave can work 2^16 seconds without rest!
   (setq pomodoro-end-time (time-add (current-time) (list 0 (* minutes 60) 0))))
 
 (defun pomodoro-tick ()


### PR DESCRIPTION
I hope this isn't taken as hypersensitivity or negativity but I know
some people would take umbrage to the default message "Back to work,
slave!", so I dropped the slave part. I realize that no ill will was
meant by this phrase and I get the joke, I just think its better off
removed. I realize this is customizable and did so on my own install,
but it seems better to err on the side of caution here, especially when
the phrase in question doesn't really contribute to the functionality or
usability. Thanks :)